### PR TITLE
fix: running finished with loading

### DIFF
--- a/apps/demo-free-layout/src/components/testrun/testrun-panel/test-run-panel.tsx
+++ b/apps/demo-free-layout/src/components/testrun/testrun-panel/test-run-panel.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { FC, useState } from 'react';
+import { FC, useState, useEffect } from 'react';
 
 import classnames from 'classnames';
 import { WorkflowInputs, WorkflowOutputs } from '@flowgram.ai/runtime-interface';
@@ -112,6 +112,26 @@ export const TestRunSidePanel: FC<TestRunSidePanelProps> = () => {
     >
       {isRunning ? 'Cancel' : 'Test Run'}
     </Button>
+  );
+
+  useEffect(() => {
+    const disposer = runtimeService.onResultChanged(({ result, errors }) => {
+      setRunning(false);
+      setResult(result);
+      if (errors) {
+        setErrors(errors);
+      } else {
+        setErrors(undefined);
+      }
+    });
+    return () => disposer.dispose();
+  }, []);
+
+  useEffect(
+    () => () => {
+      runtimeService.taskCancel();
+    },
+    [runtimeService]
   );
 
   return (

--- a/packages/plugins/panel-manager-plugin/src/components/panel-layer/float-panel.tsx
+++ b/packages/plugins/panel-manager-plugin/src/components/panel-layer/float-panel.tsx
@@ -15,7 +15,12 @@ export const FloatPanel: React.FC<{ area: Area }> = ({ area }) => {
   const panel = useRef(panelManager.getPanel(area));
   const render = () =>
     panel.current.elements.map((i) => (
-      <div className="float-panel-wrap" key={i.key} style={floatPanelWrap}>
+      <div
+        className="float-panel-wrap"
+        key={i.key}
+        style={floatPanelWrap}
+        onMouseDown={(e) => e.stopPropagation()}
+      >
         {i.el}
       </div>
     ));


### PR DESCRIPTION
- fix free-layout-demo test run cant finish loading
- stop panel wrap mouse down event to keep node selection

Fixes https://github.com/bytedance/flowgram.ai/issues/825
Fixes https://github.com/bytedance/flowgram.ai/issues/826