### PR TITLE
fix(material): The width of the variable selector will change when the content is too long, causing the container to be stretched out

### DIFF
--- a/apps/demo-free-layout/src/nodes/condition/condition-inputs/index.tsx
+++ b/apps/demo-free-layout/src/nodes/condition/condition-inputs/index.tsx
@@ -41,7 +41,7 @@ export function ConditionInputs() {
                   <div style={{ display: 'flex', alignItems: 'center' }}>
                     <ConditionRow
                       readonly={readonly}
-                      style={{ flexGrow: 1 }}
+                      style={{ flexGrow: 1, overflow: 'hidden' }}
                       value={childField.value.value}
                       onChange={(v) => childField.onChange({ value: v, key: childField.value.key })}
                     />

--- a/packages/materials/form-materials/src/components/condition-row/styles.tsx
+++ b/packages/materials/form-materials/src/components/condition-row/styles.tsx
@@ -27,4 +27,5 @@ export const UIValues = styled.div`
   flex-direction: column;
   align-items: center;
   gap: 4px;
+  overflow: hidden;
 `;


### PR DESCRIPTION
fix #908

<img width="449" height="274" alt="image" src="https://github.com/user-attachments/assets/74559111-88ed-4439-a972-7549b8073ee2" />
