### PR TITLE
fix(layout): correct vertical centering calculation with padding

### DIFF
--- a/packages/plugins/free-auto-layout-plugin/src/layout/position.ts
+++ b/packages/plugins/free-auto-layout-plugin/src/layout/position.ts
@@ -49,7 +49,10 @@ export class LayoutPosition {
     const layoutPosition: PositionSchema = {
       x: layoutNode.position.x + layoutNode.offset.x,
       // layoutNode.position.y 是中心点，但画布节点原点在上边沿的中间，所以 y 坐标需要转化后一下
-      y: layoutNode.position.y - layoutNode.size.height / 2 + layoutNode.offset.y,
+      y:
+        layoutNode.position.y +
+        layoutNode.offset.y -
+        (layoutNode.size.height - layoutNode.padding.top - layoutNode.padding.bottom) / 2,
     };
 
     const deltaX = ((layoutPosition.x - transform.position.x) * step) / 100;


### PR DESCRIPTION
<img width="1439" height="580" alt="截屏2025-12-15 16 47 39" src="https://github.com/user-attachments/assets/274f14e0-871f-4140-848d-7ac285783b1f" />
