### PR TITLE
fix(workflow-port-render): Add missing curly brace for .cross-hair in WorkflowPointStyle

### DIFF
--- a/packages/plugins/free-lines-plugin/src/components/workflow-port-render/style.ts
+++ b/packages/plugins/free-lines-plugin/src/components/workflow-port-render/style.ts
@@ -120,4 +120,5 @@ export const WorkflowPointStyle = styled.div`
       height: 2px;
       box-shadow: 4px 0 var(--g-workflow-port-color-background, #fff);
     }
+  }
 `;


### PR DESCRIPTION
It looked like the .cross-hair block was missing a closing curly brace. Added it to ensure valid CSS syntax.
<img width="688" height="643" alt="截屏2026-02-07 18 29 08" src="https://github.com/user-attachments/assets/58bbf9ab-22ac-4ffa-ad78-88ff7a514ecc" />
