### PR TITLE
Fix docs: remove extra spaces in Certimate link

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The documentation is divided into several sections:
 
 - [Coze Studio](https://github.com/coze-dev/coze-studio) is an all-in-one AI agent development tool. Providing the latest large models and tools, various development modes and frameworks, Coze Studio offers the most convenient AI agent development environment, from development to deployment.
 - [NNDeploy](https://github.com/NNDeploy/nndeploy) is a workflow-based multi-platform ai deployment tool.
-- [Certimate](https://github.com/certimate-go/certimate)  is an open-source SSL certificate management tool that helps you automatically apply for and deploy SSL certificates with a visual workflow. It is one of the ACME client options listed in the official documentation of Let's Encrypt.
+- [Certimate](https://github.com/certimate-go/certimate) is an open-source SSL certificate management tool that helps you automatically apply for and deploy SSL certificates with a visual workflow. It is one of the ACME client options listed in the official documentation of Let's Encrypt.
 
 ## 📬 Contact us
 


### PR DESCRIPTION
Fixes extra spaces in the README.md Certimate link markdown. The link had two spaces after the closing parenthesis which is unnecessary.