### PR TITLE
fix: panel manager support react16

### DIFF
--- a/apps/demo-react-16/package.json
+++ b/apps/demo-react-16/package.json
@@ -33,6 +33,7 @@
     "@flowgram.ai/free-layout-editor": "workspace:*",
     "@flowgram.ai/free-snap-plugin": "workspace:*",
     "@flowgram.ai/minimap-plugin": "workspace:*",
+    "@flowgram.ai/panel-manager-plugin": "workspace:*",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   },

--- a/apps/demo-react-16/src/components/minimap.tsx
+++ b/apps/demo-react-16/src/components/minimap.tsx
@@ -2,6 +2,7 @@
  * Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
  * SPDX-License-Identifier: MIT
  */
+import React from 'react';
 
 import { MinimapRender } from '@flowgram.ai/minimap-plugin';
 
@@ -15,6 +16,7 @@ export const Minimap = () => (
       width: 198,
     }}
   >
+    {/* @ts-ignore */}
     <MinimapRender
       containerStyles={{
         pointerEvents: 'auto',

--- a/apps/demo-react-16/src/components/node-form-panel/index.tsx
+++ b/apps/demo-react-16/src/components/node-form-panel/index.tsx
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ */
+
+export { nodeFormPanelFactory } from './sidebar-renderer';

--- a/apps/demo-react-16/src/components/node-form-panel/sidebar-renderer.tsx
+++ b/apps/demo-react-16/src/components/node-form-panel/sidebar-renderer.tsx
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ */
+
+import React, { useCallback, useEffect } from 'react';
+
+import { type PanelFactory, usePanelManager } from '@flowgram.ai/panel-manager-plugin';
+import { useClientContext, useRefresh } from '@flowgram.ai/free-layout-editor';
+
+export interface NodeFormPanelProps {
+  nodeId: string;
+}
+
+export const SidebarRenderer: React.FC<NodeFormPanelProps> = ({ nodeId }) => {
+  const panelManager = usePanelManager();
+  const { selection, playground, document } = useClientContext();
+  const refresh = useRefresh();
+  const handleClose = useCallback(() => {
+    panelManager.close(nodeFormPanelFactory.key);
+  }, []);
+  const node = nodeId ? document.getNode(nodeId) : undefined;
+  /**
+   * Listen readonly
+   */
+  useEffect(() => {
+    const disposable = playground.config.onReadonlyOrDisabledChange(() => {
+      handleClose();
+      refresh();
+    });
+    return () => disposable.dispose();
+  }, [playground]);
+  /**
+   * Listen selection
+   */
+  useEffect(() => {
+    const toDispose = selection.onSelectionChanged(() => {
+      /**
+       * 如果没有选中任何节点，则自动关闭侧边栏
+       * If no node is selected, the sidebar is automatically closed
+       */
+      if (selection.selection.length === 0) {
+        handleClose();
+      } else if (selection.selection.length === 1 && selection.selection[0] !== node) {
+        handleClose();
+      }
+    });
+    return () => toDispose.dispose();
+  }, [selection, handleClose, node]);
+  /**
+   * Close when node disposed
+   */
+  useEffect(() => {
+    if (node) {
+      const toDispose = node.onDispose(() => {
+        panelManager.close(nodeFormPanelFactory.key);
+      });
+      return () => toDispose.dispose();
+    }
+    return () => {};
+  }, [node]);
+
+  if (!node) {
+    return null;
+  }
+
+  if (playground.config.readonly) {
+    return null;
+  }
+  return (
+    <div
+      style={{
+        background: 'rgb(251, 251, 251)',
+        height: '100%',
+        borderRadius: 8,
+        border: '1px solid rgba(82,100,154, 0.13)',
+        boxSizing: 'border-box',
+      }}
+    >
+      {node.form?.getValueIn('title')} Node Form Panel
+      <input
+        onBlur={() => {
+          console.log('onBlur is before then close panel');
+        }}
+      />
+    </div>
+  );
+};
+
+export const nodeFormPanelFactory: PanelFactory<NodeFormPanelProps> = {
+  key: 'node-form-panel',
+  defaultSize: 400,
+  render: (props: NodeFormPanelProps) => <SidebarRenderer {...props} />,
+};

--- a/apps/demo-react-16/src/components/tools.tsx
+++ b/apps/demo-react-16/src/components/tools.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { usePlaygroundTools, useClientContext } from '@flowgram.ai/free-layout-editor';
 

--- a/apps/demo-react-16/src/editor.tsx
+++ b/apps/demo-react-16/src/editor.tsx
@@ -2,6 +2,7 @@
  * Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
  * SPDX-License-Identifier: MIT
  */
+import React from 'react';
 
 import { EditorRenderer, FreeLayoutEditorProvider } from '@flowgram.ai/free-layout-editor';
 
@@ -15,10 +16,12 @@ import './index.css';
 export const Editor = () => {
   const editorProps = useEditorProps();
   return (
+    /** @ts-ignore */
     <FreeLayoutEditorProvider {...editorProps}>
       <div className="demo-free-container">
         <div className="demo-free-layout">
           <NodeAddPanel />
+          {/* @ts-ignore */}
           <EditorRenderer className="demo-free-editor" />
         </div>
         <Tools />

--- a/apps/demo-react-16/src/hooks/use-editor-props.tsx
+++ b/apps/demo-react-16/src/hooks/use-editor-props.tsx
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { useMemo } from 'react';
+import React, { useMemo } from 'react';
 
+import { createPanelManagerPlugin, usePanelManager } from '@flowgram.ai/panel-manager-plugin';
 import { createMinimapPlugin } from '@flowgram.ai/minimap-plugin';
 import { createFreeSnapPlugin } from '@flowgram.ai/free-snap-plugin';
 import {
@@ -17,6 +18,7 @@ import {
 
 import { nodeRegistries } from '../node-registries';
 import { initialData } from '../initial-data';
+import { nodeFormPanelFactory } from '../components/node-form-panel';
 
 export const useEditorProps = () =>
   useMemo<FreeLayoutProps>(
@@ -74,10 +76,20 @@ export const useEditorProps = () =>
          */
         renderDefaultNode: (props: WorkflowNodeProps) => {
           const { form } = useNodeRender();
+          const panelManager = usePanelManager();
           return (
-            <WorkflowNodeRenderer className="demo-free-node" node={props.node}>
-              {form?.render()}
-            </WorkflowNodeRenderer>
+            <div
+              onClick={() =>
+                panelManager.open(nodeFormPanelFactory.key, 'right', {
+                  props: { nodeId: props.node.id },
+                })
+              }
+            >
+              {/* @ts-ignore */}
+              <WorkflowNodeRenderer className="demo-free-node" node={props.node}>
+                {form?.render()}
+              </WorkflowNodeRenderer>
+            </div>
           );
         },
       },
@@ -152,6 +164,13 @@ export const useEditorProps = () =>
           edgeLineWidth: 1,
           alignLineWidth: 1,
           alignCrossWidth: 8,
+        }),
+        /**
+         * Panel manager plugin
+         * 面板管理插件
+         */
+        createPanelManagerPlugin({
+          factories: [nodeFormPanelFactory],
         }),
       ],
     }),

--- a/apps/demo-react-16/tsconfig.json
+++ b/apps/demo-react-16/tsconfig.json
@@ -16,8 +16,8 @@
     "allowJs": true,
     "resolveJsonModule": true,
     "types": ["node"],
-    "jsx": "react-jsx",
+    "jsx": "react",
     "lib": ["es6", "dom", "es2020", "es2019.Array"]
   },
-  "include": ["./src"],
+  "include": ["./src"]
 }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -824,6 +824,9 @@ importers:
       '@flowgram.ai/minimap-plugin':
         specifier: workspace:*
         version: link:../../packages/plugins/minimap-plugin
+      '@flowgram.ai/panel-manager-plugin':
+        specifier: workspace:*
+        version: link:../../packages/plugins/panel-manager-plugin
       react:
         specifier: ^16.8.6
         version: 16.14.0
@@ -3970,8 +3973,8 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0(react@18.3.1)
       zustand:
-        specifier: ^5.0.8
-        version: 5.0.8(@types/react@18.3.24)(immer@10.1.3)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
+        specifier: ^4.5.5
+        version: 4.5.7(@types/react@18.3.24)(immer@10.1.3)(react@18.3.1)
     devDependencies:
       '@flowgram.ai/eslint-config':
         specifier: workspace:*
@@ -4145,8 +4148,8 @@ importers:
         specifier: ^5.0.9
         version: 5.1.5
       zustand:
-        specifier: ^5.0.8
-        version: 5.0.8(@types/react@18.3.24)(immer@10.1.3)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
+        specifier: ^4.5.5
+        version: 4.5.7(@types/react@18.3.24)(immer@10.1.3)(react@18.3.1)
     devDependencies:
       '@flowgram.ai/eslint-config':
         specifier: workspace:*
@@ -13222,22 +13225,19 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zustand@5.0.8:
-    resolution: {integrity: sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==}
-    engines: {node: '>=12.20.0'}
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
     peerDependencies:
-      '@types/react': '>=18.0.0'
+      '@types/react': '>=16.8'
       immer: '>=9.0.6'
-      react: '>=18.0.0'
-      use-sync-external-store: '>=1.2.0'
+      react: '>=16.8'
     peerDependenciesMeta:
       '@types/react':
         optional: true
       immer:
         optional: true
       react:
-        optional: true
-      use-sync-external-store:
         optional: true
 
   zwitch@2.0.4:
@@ -24306,11 +24306,12 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zustand@5.0.8(@types/react@18.3.24)(immer@10.1.3)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)):
+  zustand@4.5.7(@types/react@18.3.24)(immer@10.1.3)(react@18.3.1):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.24
       immer: 10.1.3
       react: 18.3.1
-      use-sync-external-store: 1.6.0(react@18.3.1)
 
   zwitch@2.0.4: {}

--- a/packages/plugins/panel-manager-plugin/package.json
+++ b/packages/plugins/panel-manager-plugin/package.json
@@ -26,7 +26,7 @@
     "inversify": "^6.0.1",
     "clsx": "^1.1.1",
     "nanoid": "^5.0.9",
-    "zustand": "^5.0.8",
+    "zustand": "^4.5.5",
     "use-sync-external-store": "^1.6.0",
     "@flowgram.ai/core": "workspace:*",
     "@flowgram.ai/utils": "workspace:*"

--- a/packages/plugins/panel-manager-plugin/src/components/panel-layer/docked-panel-layer.tsx
+++ b/packages/plugins/panel-manager-plugin/src/components/panel-layer/docked-panel-layer.tsx
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 
+import * as React from 'react';
+
 import { PanelLayer, PanelLayerProps } from './panel-layer';
 
 export type DockedPanelLayerProps = Omit<PanelLayerProps, 'mode'>;

--- a/packages/plugins/panel-manager-plugin/src/components/panel-layer/panel-layer.tsx
+++ b/packages/plugins/panel-manager-plugin/src/components/panel-layer/panel-layer.tsx
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 
+import * as React from 'react';
+
 import clsx from 'clsx';
 
 import { useGlobalCSS } from '../../hooks/use-global-css';

--- a/packages/plugins/panel-manager-plugin/src/components/panel-layer/panel.tsx
+++ b/packages/plugins/panel-manager-plugin/src/components/panel-layer/panel.tsx
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { useEffect, startTransition, useState, useRef } from 'react';
+import * as React from 'react';
+
+const { useEffect, useState, useRef } = React;
 
 import { clsx } from 'clsx';
 
@@ -95,10 +97,21 @@ export const PanelArea: React.FC<{ area: Area }> = ({ area }) => {
   const [panels, setPanels] = useState(panelManager.getPanels(area));
 
   useEffect(() => {
+    let pending: number;
+
+    function startTransition(fn: () => void) {
+      clearTimeout(pending);
+      pending = setTimeout(fn, 0);
+    }
     const dispose = panelManager.onPanelsChange(() => {
-      startTransition(() => {
-        setPanels(panelManager.getPanels(area));
-      });
+      const r: any = { ...React };
+
+      const start = r['startTransition'] as undefined | ((cb: () => void) => void);
+      if (typeof start === 'function') {
+        start(() => setPanels(panelManager.getPanels(area)));
+      } else {
+        startTransition(() => setPanels(panelManager.getPanels(area)));
+      }
     });
     return () => dispose.dispose();
   }, []);

--- a/packages/plugins/panel-manager-plugin/src/components/resize-bar/index.tsx
+++ b/packages/plugins/panel-manager-plugin/src/components/resize-bar/index.tsx
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-import React, { useRef, useState } from 'react';
+import * as React from 'react';
+
+const { useRef, useState } = React;
 
 interface Props {
   size: number;

--- a/packages/plugins/panel-manager-plugin/tsconfig.json
+++ b/packages/plugins/panel-manager-plugin/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "@flowgram.ai/ts-config/tsconfig.flow.base.json",
   "compilerOptions": {
-    "jsx": "react-jsx"
+    "jsx": "react"
   },
-  "include": [
-    "./src"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["./src"],
+  "exclude": ["node_modules"]
 }

--- a/packages/plugins/test-run-plugin/package.json
+++ b/packages/plugins/test-run-plugin/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "inversify": "^6.0.1",
     "nanoid": "^5.0.9",
-    "zustand": "^5.0.8",
+    "zustand": "^4.5.5",
     "@flowgram.ai/form-core": "workspace:*",
     "@flowgram.ai/core": "workspace:*",
     "@flowgram.ai/utils": "workspace:*",


### PR DESCRIPTION
- PanelManagerPlugin 支持 React16
- 降级所依赖的 zustand 版本 ^5.0.8 => ^4.5.5
- 完善 demo-react-16 

Fixes #1098 