### PR TITLE
fix(json-schema-editor): initialize default on type switch

### DIFF
--- a/packages/materials/form-antd-materials/src/components/json-schema-editor/index.tsx
+++ b/packages/materials/form-antd-materials/src/components/json-schema-editor/index.tsx
@@ -6,6 +6,7 @@
 import React, { useMemo, useState } from 'react';
 
 import { Button, Checkbox } from 'antd';
+import { I18n } from '@flowgram.ai/editor';
 import {
   DownOutlined,
   ExpandAltOutlined,
@@ -39,7 +40,26 @@ import {
 import { usePropertiesEdit } from './hooks';
 import { DefaultValue } from './default-value';
 import { BlurInput } from './components/blur-input';
-import { I18n } from '@flowgram.ai/editor';
+
+function getSchemaDefaultValue(schema: Partial<IJsonSchema> | undefined) {
+  switch (schema?.type) {
+    case 'string':
+      return '';
+    case 'integer':
+    case 'number':
+      return 0;
+    case 'boolean':
+      return false;
+    case 'object':
+      return '{}';
+    case 'array':
+      return '[]';
+    case 'map':
+      return '[]';
+    default:
+      return undefined;
+  }
+}
 
 export function JsonSchemaEditor(props: {
   value?: IJsonSchema;
@@ -166,9 +186,11 @@ function PropertyEdit(props: {
               <TypeSelector
                 value={typeSelectorValue}
                 onChange={(_value) => {
+                  const nextTypeSchema = _value || {};
                   onChangeProps?.({
                     ...(value || {}),
-                    ..._value,
+                    ...nextTypeSchema,
+                    default: getSchemaDefaultValue(nextTypeSchema),
                   });
                 }}
               />

--- a/packages/materials/form-materials/src/components/json-schema-editor/index.tsx
+++ b/packages/materials/form-materials/src/components/json-schema-editor/index.tsx
@@ -5,7 +5,7 @@
 
 import React, { useMemo, useState } from 'react';
 
-import { IJsonSchema } from '@flowgram.ai/json-schema';
+import { IJsonSchema, JsonSchemaTypeManager, useTypeManager } from '@flowgram.ai/json-schema';
 import { I18n } from '@flowgram.ai/editor';
 import { Button, Checkbox, IconButton } from '@douyinfe/semi-ui';
 import {
@@ -28,6 +28,21 @@ import { DefaultValue } from './default-value';
 import './styles.css';
 
 const DEFAULT = { type: 'object' };
+
+function getSchemaDefaultValue(
+  typeManager: JsonSchemaTypeManager,
+  schema: Partial<IJsonSchema> | undefined
+) {
+  if (schema?.type === 'object') {
+    return '{}';
+  }
+
+  if (schema?.type === 'array') {
+    return '[]';
+  }
+
+  return typeManager.getDefaultValue(schema || {});
+}
 
 export function JsonSchemaEditor(props: {
   value?: IJsonSchema;
@@ -86,6 +101,7 @@ function PropertyEdit(props: {
 
   const [expand, setExpand] = useState(false);
   const [collapse, setCollapse] = useState(false);
+  const typeManager = useTypeManager() as JsonSchemaTypeManager;
 
   const { name, type, items, default: defaultValue, description, isPropertyRequired } = value || {};
 
@@ -136,9 +152,11 @@ function PropertyEdit(props: {
                 value={typeSelectorValue}
                 readonly={readonly}
                 onChange={(_value) => {
+                  const nextTypeSchema = _value || {};
                   onChangeProps?.({
                     ...(value || {}),
-                    ..._value,
+                    ...nextTypeSchema,
+                    default: getSchemaDefaultValue(typeManager, nextTypeSchema),
                   });
                 }}
               />


### PR DESCRIPTION
## Summary
- initialize `schema.default` when switching field type in JsonSchemaEditor
- align semi and antd editors for primitive and container defaults
- use JSON string defaults for object/array editors to match current editor value shape

## Validation
- pnpm --dir packages/materials/form-materials ts-check
- pnpm --dir packages/materials/form-antd-materials ts-check

Fixes #1041

在类型切换时生效:

<img width="392" height="174" alt="image" src="https://github.com/user-attachments/assets/a7ba6684-2388-47d0-83ce-31464ea1e7d4" />
