### PR TITLE
fix(form): correct operator precedence in FieldArray default value check

### DIFF
--- a/packages/node-engine/form/src/react/field-array.tsx
+++ b/packages/node-engine/form/src/react/field-array.tsx
@@ -67,7 +67,7 @@ export function FieldArray<TValue extends FieldValue>({
     }
     fieldModel.renderCount = fieldModel.renderCount + 1;
 
-    if (!formModel.getValueIn(name) !== undefined && defaultValue !== undefined) {
+    if (formModel.getValueIn(name) === undefined && defaultValue !== undefined) {
       formModel.setInitValueIn(name, defaultValue);
       refresh();
     }


### PR DESCRIPTION
## Summary
- Fixed incorrect boolean operator precedence in `FieldArray` component (`packages/node-engine/form/src/react/field-array.tsx`, line 70)
- The original condition `!formModel.getValueIn(name) !== undefined` evaluates as `(!formModel.getValueIn(name)) !== undefined` due to `!` having higher precedence than `!==`
- Since `!` always returns a boolean (`true` or `false`), and `boolean !== undefined` is always `true`, this condition was always `true` whenever `defaultValue` was provided

## Problem
This bug causes **existing field values to be silently overwritten** with the default value on every render of the `FieldArray` component, whenever a `defaultValue` prop is supplied.

## Fix
Changed to `formModel.getValueIn(name) === undefined` to correctly check if the field has no value before applying the default.

## Test plan
- [ ] Verify that `FieldArray` with a `defaultValue` prop does not overwrite existing values on re-render
- [ ] Verify that `FieldArray` still correctly applies `defaultValue` when the field is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)