### PR TITLE
fix(type-editor): use position instead of display for hidden clipboard textarea

### DIFF
--- a/packages/materials/type-editor/src/services/clipboard-service.ts
+++ b/packages/materials/type-editor/src/services/clipboard-service.ts
@@ -54,7 +54,7 @@ export class ClipboardService {
         textarea.value = newStrData;
 
         // 视区以外渲染 dom，无法 display none，否则无文本 copy
-        textarea.style.display = 'absolute';
+        textarea.style.position = 'absolute';
         textarea.style.left = '-99999999px';
 
         document.body.prepend(textarea);


### PR DESCRIPTION
## Summary
- Fixed invalid CSS property value in clipboard fallback (`packages/materials/type-editor/src/services/clipboard-service.ts`, line 57)
- Changed `textarea.style.display = 'absolute'` to `textarea.style.position = 'absolute'`

## Problem
`display: 'absolute'` is not valid CSS — `'absolute'` is a value for the `position` property, not `display`. The comment on line 56 explicitly states the intent is to render the textarea outside the viewport. Since the browser ignores the invalid `display` value, the textarea remains visible (default `display: inline` for `<textarea>`) and may briefly flash on screen during clipboard copy operations in browsers that don't support the Clipboard API.

## Fix
Changed to `textarea.style.position = 'absolute'` so the element is properly positioned off-screen.

## Test plan
- [ ] Test clipboard copy in a non-secure context (where Clipboard API is unavailable) and verify no textarea flash
- [ ] Verify copy functionality still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)