### PR TITLE
fix(type-editor): remove invalid navigator.clipboard.dispatchEvent call

### DIFF
--- a/packages/materials/type-editor/src/services/clipboard-service.ts
+++ b/packages/materials/type-editor/src/services/clipboard-service.ts
@@ -45,10 +45,6 @@ export class ClipboardService {
     if (oldSaveData.error || oldSaveData.data !== newStrData) {
       if (navigator.clipboard && window.isSecureContext) {
         await navigator.clipboard.writeText(newStrData);
-        const event = document.createEvent('Event');
-        event.initEvent('onchange');
-        (event as unknown as { value: string }).value = newStrData;
-        navigator.clipboard.dispatchEvent(event);
       } else {
         const textarea = document.createElement('textarea');
         textarea.value = newStrData;


### PR DESCRIPTION
## Summary
- Removed invalid `navigator.clipboard.dispatchEvent()` call and associated deprecated APIs in `packages/materials/type-editor/src/services/clipboard-service.ts` (lines 48-51)

## Problem
The removed code block had multiple issues:
1. `navigator.clipboard.dispatchEvent()` — dispatching custom events on the Clipboard object serves no purpose; no listener would receive this event
2. `document.createEvent('Event')` and `event.initEvent()` — deprecated DOM APIs
3. Event name `'onchange'` — the `on` prefix is for handler attributes, not event names (should be `'change'`)
4. The code either silently fails or may throw `TypeError` in restricted browser contexts

The internal notification is already handled correctly by `onClipboardChangedEmitter.fire()` on the line after this block.

## Fix
Removed the entire dead code block (4 lines). The `onClipboardChangedEmitter.fire()` call already provides proper internal notification after a successful clipboard write.

## Test plan
- [ ] Verify clipboard write still triggers internal change notifications
- [ ] Verify clipboard copy functionality works in both secure and non-secure contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)