### PR TITLE
fix(minimap): add explicit return false in transformVisibles filter

### DIFF
--- a/packages/plugins/minimap-plugin/src/service.ts
+++ b/packages/plugins/minimap-plugin/src/service.ts
@@ -257,14 +257,14 @@ export class FlowMinimapService {
       // 去除不可见节点
       if (node.hidden) return false;
       // 去除根节点
-      if (node.flowNodeType === FlowNodeBaseType.ROOT) return;
+      if (node.flowNodeType === FlowNodeBaseType.ROOT) return false;
       // 去除非一级节点
       if (
         !this.options.enableDisplayAllNodes &&
         node.parent &&
         node.parent.flowNodeType !== FlowNodeBaseType.ROOT
       )
-        return;
+        return false;
       return true;
     });
   }


### PR DESCRIPTION
## Summary
- Changed bare `return;` to explicit `return false;` in two places within the `transformVisibles` filter callback (`packages/plugins/minimap-plugin/src/service.ts`, lines 260 and 267)

## Problem
In the `transformVisibles` getter, two `return;` statements return `undefined` instead of `false` within an `Array.filter()` callback. While `undefined` is falsy and produces the correct filtering behavior, it is inconsistent with the explicit `return false` on line 258 and `return true` on line 268 in the same callback.

This inconsistency can confuse maintainers and may cause issues if the logic is ever refactored to use type-aware utilities.

## Fix
Changed both bare `return;` to `return false;` for consistency with the rest of the callback.

## Test plan
- [ ] Verify minimap still correctly filters out root nodes and non-first-level nodes
- [ ] Visual check of minimap rendering in free-layout demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)