### PR TITLE
fix(node): add missing dependencies to useWatchFormValueIn useEffect

### DIFF
--- a/packages/node-engine/node/src/hooks.ts
+++ b/packages/node-engine/node/src/hooks.ts
@@ -49,7 +49,7 @@ export function useWatchFormValueIn<T = any>(node: FlowNodeEntity, name: string)
     });
 
     return () => disposable?.dispose();
-  }, []);
+  }, [name, formModel.nativeFormModel]);
 
   return formModel.getValueIn<T>(name);
 }


### PR DESCRIPTION
## Summary
- Fixed stale closure in `useWatchFormValueIn` hook (`packages/node-engine/node/src/hooks.ts`, line 52)
- Added `name` and `formModel.nativeFormModel` to the `useEffect` dependency array

## Problem
The `useEffect` in `useWatchFormValueIn` had an empty dependency array `[]`, but the closure captures `name` from the outer scope. When the `name` prop changes dynamically (e.g., a form field selector that switches which field it watches), the subscription still filters for the old field name. The component won't re-render when the new field's value changes.

Compare with the sibling hook `useWatchFormValues` (line 30) which correctly includes `formModel.nativeFormModel` in its dependency array.

## Fix
Changed the dependency array from `[]` to `[name, formModel.nativeFormModel]` so the subscription is properly re-created when the watched field name changes.

## Test plan
- [ ] Verify `useWatchFormValueIn` re-subscribes when `name` prop changes
- [ ] Verify form value watching still works correctly for static field names

🤖 Generated with [Claude Code](https://claude.com/claude-code)