### PR TITLE
fix(form-materials): support enum constant input

### DIFF
--- a/apps/docs/components/form-materials/components/constant-inputs.tsx
+++ b/apps/docs/components/form-materials/components/constant-inputs.tsx
@@ -35,6 +35,17 @@ export const BasicStory = () => (
               )}
             </Field>
 
+            <b>Enum</b>
+            <Field<string> name="constant_enum" defaultValue="morning">
+              {({ field }) => (
+                <ConstantInput
+                  value={field.value}
+                  onChange={(value) => field.onChange(value)}
+                  schema={{ type: 'string', enum: ['morning', 'afternoon'] }}
+                />
+              )}
+            </Field>
+
             <b>Number</b>
             <Field<number> name="constant_number" defaultValue={42}>
               {({ field }) => (

--- a/apps/docs/src/en/materials/components/constant-input.mdx
+++ b/apps/docs/src/en/materials/components/constant-input.mdx
@@ -27,6 +27,15 @@ const formMeta = {
           />
         )}
       </Field>
+      <Field<string> name="constant_enum" defaultValue="morning">
+        {({ field }) => (
+          <ConstantInput
+            value={field.value}
+            onChange={(value) => field.onChange(value)}
+            schema={{ type: 'string', enum: ['morning', 'afternoon'] }}
+          />
+        )}
+      </Field>
     </>
   ),
 }

--- a/apps/docs/src/zh/materials/components/constant-input.mdx
+++ b/apps/docs/src/zh/materials/components/constant-input.mdx
@@ -27,6 +27,15 @@ const formMeta = {
           />
         )}
       </Field>
+      <Field<string> name="constant_enum" defaultValue="上午">
+        {({ field }) => (
+          <ConstantInput
+            value={field.value}
+            onChange={(value) => field.onChange(value)}
+            schema={{ type: 'string', enum: ['上午', '下午'] }}
+          />
+        )}
+      </Field>
     </>
   ),
 }
@@ -174,4 +183,3 @@ ConstantInput 与 [**物料类型管理**](../common/json-schema-preset) 深度�
 
 [**Semi UI**](https://semi.design/zh-CN)
 - 基础输入组件库，提供默认的输入控件
-

--- a/packages/materials/form-materials/src/components/constant-input/index.tsx
+++ b/packages/materials/form-materials/src/components/constant-input/index.tsx
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-/* eslint-disable react/prop-types */
 import React, { useMemo } from 'react';
 
 import { Input } from '@douyinfe/semi-ui';
@@ -27,7 +26,7 @@ export function ConstantInput(props: PropsType) {
     }
 
     return strategy?.Renderer;
-  }, [strategies, schema]);
+  }, [strategies, schema, typeManager]);
 
   if (!Renderer) {
     if (fallbackRenderer) {
@@ -35,11 +34,14 @@ export function ConstantInput(props: PropsType) {
         value,
         onChange,
         readonly,
+        schema,
         ...rest,
       });
     }
     return <Input size="small" disabled placeholder="Unsupported type" />;
   }
 
-  return <Renderer value={value} onChange={onChange} readonly={readonly} {...rest} />;
+  return (
+    <Renderer value={value} onChange={onChange} readonly={readonly} schema={schema} {...rest} />
+  );
 }

--- a/packages/materials/form-materials/src/plugins/json-schema-preset/type-definition/boolean.tsx
+++ b/packages/materials/form-materials/src/plugins/json-schema-preset/type-definition/boolean.tsx
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-/* eslint-disable react/prop-types */
 import React from 'react';
 
 import { I18n } from '@flowgram.ai/editor';
@@ -16,12 +15,12 @@ import { type JsonSchemaTypeRegistry } from '../types';
 export const booleanRegistry: Partial<JsonSchemaTypeRegistry> = {
   type: 'boolean',
   ConstantRenderer: (props) => {
-    const { value, onChange, ...rest } = props;
+    const { value, onChange, readonly, schema, ...rest } = props;
     return (
       <Select
         placeholder={I18n.t('Please Select Boolean')}
         size="small"
-        disabled={props.readonly}
+        disabled={readonly}
         optionList={[
           { label: I18n.t('True'), value: 1 },
           { label: I18n.t('False'), value: 0 },

--- a/packages/materials/form-materials/src/plugins/json-schema-preset/type-definition/date-time.tsx
+++ b/packages/materials/form-materials/src/plugins/json-schema-preset/type-definition/date-time.tsx
@@ -36,21 +36,25 @@ const stringifyDateTime = (value: unknown) => {
 
 export const dateTimeRegistry: Partial<JsonSchemaTypeRegistry> = {
   type: 'date-time',
-  ConstantRenderer: (props: DatePickerProps & { readonly?: boolean }) => (
-    <DatePicker
-      size="small"
-      type="dateTime"
-      density="compact"
-      defaultValue={Date.now()}
-      style={{ width: '100%', ...(props.style || {}) }}
-      disabled={props.readonly}
-      {...props}
-      onChange={(date) => {
-        props.onChange?.(stringifyDateTime(date));
-      }}
-      value={props.value}
-    />
-  ),
+  ConstantRenderer: (props: DatePickerProps & { readonly?: boolean; schema?: unknown }) => {
+    const { readonly, schema, ...rest } = props;
+
+    return (
+      <DatePicker
+        size="small"
+        type="dateTime"
+        density="compact"
+        defaultValue={Date.now()}
+        style={{ width: '100%', ...(rest.style || {}) }}
+        disabled={readonly}
+        {...rest}
+        onChange={(date) => {
+          rest.onChange?.(stringifyDateTime(date));
+        }}
+        value={rest.value}
+      />
+    );
+  },
   conditionRule: {
     [ConditionPresetOp.EQ]: { type: 'date-time' },
     [ConditionPresetOp.NEQ]: { type: 'date-time' },

--- a/packages/materials/form-materials/src/plugins/json-schema-preset/type-definition/enum.tsx
+++ b/packages/materials/form-materials/src/plugins/json-schema-preset/type-definition/enum.tsx
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ */
+
+import React from 'react';
+
+import { Select } from '@douyinfe/semi-ui';
+
+import { type JsonSchemaTypeRegistry } from '../types';
+
+export const enumRegistry: Partial<JsonSchemaTypeRegistry> = {
+  type: 'enum',
+  parentType: [],
+  ConstantRenderer: (props) => {
+    const { schema, readonly, enableMultiLineStr, ...rest } = props;
+
+    return (
+      <Select
+        size="small"
+        disabled={readonly}
+        optionList={(schema?.enum || []).map((value) => ({
+          label: `${value}`,
+          value,
+        }))}
+        {...rest}
+      />
+    );
+  },
+};

--- a/packages/materials/form-materials/src/plugins/json-schema-preset/type-definition/index.tsx
+++ b/packages/materials/form-materials/src/plugins/json-schema-preset/type-definition/index.tsx
@@ -10,6 +10,7 @@ import { objectRegistry } from './object';
 import { numberRegistry } from './number';
 import { mapRegistry } from './map';
 import { integerRegistry } from './integer';
+import { enumRegistry } from './enum';
 import { dateTimeRegistry } from './date-time';
 import { booleanRegistry } from './boolean';
 import { arrayRegistry } from './array';
@@ -23,6 +24,7 @@ export const jsonSchemaTypePreset = [
   booleanRegistry,
   arrayRegistry,
   mapRegistry,
+  enumRegistry,
   dateTimeRegistry,
 ];
 

--- a/packages/materials/form-materials/src/plugins/json-schema-preset/type-definition/integer.tsx
+++ b/packages/materials/form-materials/src/plugins/json-schema-preset/type-definition/integer.tsx
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-/* eslint-disable react/prop-types */
 import React from 'react';
 
 import { I18n } from '@flowgram.ai/editor';
@@ -15,13 +14,13 @@ import { type JsonSchemaTypeRegistry } from '../types';
 
 export const integerRegistry: Partial<JsonSchemaTypeRegistry> = {
   type: 'integer',
-  ConstantRenderer: (props) => (
+  ConstantRenderer: ({ readonly, schema, ...rest }) => (
     <InputNumber
       placeholder={I18n.t('Please Input Integer')}
       size="small"
-      disabled={props.readonly}
+      disabled={readonly}
       precision={0}
-      {...props}
+      {...rest}
     />
   ),
   conditionRule: {

--- a/packages/materials/form-materials/src/plugins/json-schema-preset/type-definition/number.tsx
+++ b/packages/materials/form-materials/src/plugins/json-schema-preset/type-definition/number.tsx
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-/* eslint-disable react/prop-types */
 import React from 'react';
 
 import { I18n } from '@flowgram.ai/editor';
@@ -15,13 +14,13 @@ import { type JsonSchemaTypeRegistry } from '../types';
 
 export const numberRegistry: Partial<JsonSchemaTypeRegistry> = {
   type: 'number',
-  ConstantRenderer: (props) => (
+  ConstantRenderer: ({ readonly, schema, ...rest }) => (
     <InputNumber
       placeholder={I18n.t('Please Input Number')}
       size="small"
-      disabled={props.readonly}
+      disabled={readonly}
       hideButtons
-      {...props}
+      {...rest}
     />
   ),
   conditionRule: {

--- a/packages/materials/form-materials/src/plugins/json-schema-preset/type-definition/string.tsx
+++ b/packages/materials/form-materials/src/plugins/json-schema-preset/type-definition/string.tsx
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-/* eslint-disable react/prop-types */
 import React from 'react';
 
 import { I18n } from '@flowgram.ai/editor';
@@ -15,21 +14,21 @@ import { type JsonSchemaTypeRegistry } from '../types';
 
 export const stringRegistry: Partial<JsonSchemaTypeRegistry> = {
   type: 'string',
-  ConstantRenderer: (props) =>
-    props?.enableMultiLineStr ? (
+  ConstantRenderer: ({ readonly, schema, enableMultiLineStr, ...rest }) =>
+    enableMultiLineStr ? (
       <TextArea
         autosize
         rows={1}
         placeholder={I18n.t('Please Input String')}
-        disabled={props.readonly}
-        {...props}
+        disabled={readonly}
+        {...rest}
       />
     ) : (
       <Input
         size="small"
         placeholder={I18n.t('Please Input String')}
-        disabled={props.readonly}
-        {...props}
+        disabled={readonly}
+        {...rest}
       />
     ),
   conditionRule: {

--- a/packages/materials/form-materials/src/plugins/json-schema-preset/types.ts
+++ b/packages/materials/form-materials/src/plugins/json-schema-preset/types.ts
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { JsonSchemaTypeRegistry as OriginJsonSchemaTypeRegistry } from '@flowgram.ai/json-schema';
+import {
+  type IJsonSchema,
+  JsonSchemaTypeRegistry as OriginJsonSchemaTypeRegistry,
+} from '@flowgram.ai/json-schema';
 
 import { IConditionRule, IConditionRuleFactory } from '@/components/condition-context/types';
 
@@ -11,6 +14,7 @@ export interface ConstantRendererProps<Value = any> {
   value?: Value;
   onChange?: (value: Value) => void;
   readonly?: boolean;
+  schema?: IJsonSchema;
   [key: string]: any;
 }
 export interface JsonSchemaTypeRegistry<Value = any> extends OriginJsonSchemaTypeRegistry {


### PR DESCRIPTION

<img width="506" height="217" alt="image" src="https://github.com/user-attachments/assets/703134c3-b581-453c-bbca-29b0a33599d1" />

## Summary
- add an enum constant renderer for form-materials JSON schema preset
- pass schema into ConstantRenderer consistently and avoid leaking schema into built-in Semi renderers
- document enum ConstantInput usage in English and Chinese docs

## Root Cause
Schemas with an enum constraint are resolved as the enum type by JsonSchemaTypeManager, but form-materials did not register a ConstantRenderer for enum, so ConstantInput fell back to Unsupported type.

## Validation
- rush ts-check --to @flowgram.ai/form-materials
- rush lint --to @flowgram.ai/docs

Fixes #1126